### PR TITLE
Fix su daemon init on devices with pin/password encryption

### DIFF
--- a/su.patch
+++ b/su.patch
@@ -935,7 +935,6 @@ index b71908c..cadc251 100644
 +    class main
 +    user root
 +    seclabel u:r:su:s0
-+    oneshot
 +
  service racoon /system/bin/racoon
      class main


### PR DESCRIPTION
Ref (Android Init Language): https://github.com/android/platform_system_core/blob/master/init/readme.txt
Ref (Full Disk Encryption): https://source.android.com/devices/tech/security/encryption/

Basically, when we have an encrypted volume (not using the default password/not the forceencrypt way), Android starts up with a minimal framework to load the pin/password entry screen, which call the class_start main, thereby starting all services in class main. At this point only services in class main and class core are started.
Once the password has been verified, Android calls the class_reset main (thereby killing all services in class main) and then loads the full framework which involves calling class_start main & class_start late_start. At this point, services in class main are restarted and those in class late_start are started for the first time. Services in class core were never killed and continue running.

So here's what happens when we have this (code from your patch):
service daemonsu /sbin/su --daemon
    class main
    user root
    seclabel u:r:su:s0
    oneshot
1. When the minimal framework is loaded (to display the pin/password prompt), daemonsu starts up just fine when class_start main is called.
2. After verifying the password, daemonsu is killed because class_reset main is called
3. Since daemonsu is defined as oneshot (which means do not restart the service when it exits), when class_start main is called again, daemonsu is not restarted

In short, because class main is started twice for devices with encrypted data and because daemonsu is oneshot, daemonsu doesn't start when class main is started to second time.

Solution:. Remove oneshot from the daemonsu service definition to allow daemonsu to respawn when class main is restarted
service daemonsu /sbin/su --daemon
    class main
    user root
    seclabel u:r:su:s0
